### PR TITLE
Writeprotectedmemory

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,14 @@ memoryjs.writeMemory(handle, address, value, dataType);
 
 See the [Documentation](#user-content-documentation) section of this README to see what values `dataType` can be.
 
+Set protection of memory:
+``` javascript
+var oldProtection = memoryjs.setProtection(handle, address, size, protection);
+```
+
+See the [Documentation](#user-content-protection-type) section of this README to see what values `protection` can be.
+
+
 ### Pattern scanning
 
 Pattern scanning (sync):
@@ -183,10 +191,19 @@ memoryjs.writeMemory(address, vector3);
 
 Vector4 is a data structure of four floats:
 
-```javascript
+``` javascript
 const vector4 = { w: 0.0, x: 0.0, y: 0.0, z: 0.0 };
 memoryjs.writeMemory(address, vector4);
 ```
+
+### Protection Type:
+
+Protection type is a bit flag DWORD value.
+
+This parameter should reference a constant from the library:
+
+`memoryjs.PAGE_NOACCESS, memoryjs.PAGE_READONLY, memoryjs.PAGE_READWRITE, memoryjs.PAGE_WRITECOPY, memoryjs.PAGE_EXECUTE, memoryjs.PAGE_EXECUTE_READ, memoryjs.PAGE_EXECUTE_READWRITE, memoryjs.PAGE_EXECUTE_WRITECOPY, memoryjs.PAGE_GUARD, memoryjs.PAGE_NOCACHE, memoryjs.PAGE_WRITECOMBINE, memoryjs.PAGE_ENCLAVE_THREAD_CONTROL, memoryjs.PAGE_TARGETS_NO_UPDATE, memoryjs.PAGE_TARGETS_INVALID, memoryjs.PAGE_ENCLAVE_UNVALIDATED`
+
 
 ### Strings:
 
@@ -328,3 +345,16 @@ pattern scans memory to find an offset
   - **offset** *(int)* - value of the offset found (will return -1 if the module was not found, -2 if the pattern found no address)
 
 **returns** the value of the offset found
+
+---
+
+#### setProtection(handle, address, size, protection)
+
+sets the protection of the memory address
+
+- **handle** *(int)* - the handle of the process, given to you by the process object retrieved when opening the process
+- **address** *(int)* - the address in memory to write to
+- **size** *(int)* - `number` of bytes at the address to change the protection of.
+- **protection** *(int)* the protection type to set this if a bit flag. See [Documentation](#user-content-protection-type)
+
+**returns** old protection value.

--- a/index.js
+++ b/index.js
@@ -24,6 +24,24 @@ module.exports = {
   READ: 0x1,
   SUBTRACT: 0x2,
 
+  // Memory access types.
+  // See: https://docs.microsoft.com/en-gb/windows/desktop/Memory/memory-protection-constants
+  PAGE_NOACCESS: 0x01,
+  PAGE_READONLY: 0x02,
+  PAGE_READWRITE: 0x04,
+  PAGE_WRITECOPY: 0x08,
+  PAGE_EXECUTE: 0x10,
+  PAGE_EXECUTE_READ: 0x20,
+  PAGE_EXECUTE_READWRITE: 0x40,
+  PAGE_EXECUTE_WRITECOPY: 0x80,
+  PAGE_GUARD: 0x100,
+  PAGE_NOCACHE: 0x200,
+  PAGE_WRITECOMBINE: 0x400,
+  PAGE_ENCLAVE_THREAD_CONTROL: 0x80000000,
+  PAGE_TARGETS_NO_UPDATE: 0x40000000,
+  PAGE_TARGETS_INVALID: 0x40000000,
+  PAGE_ENCLAVE_UNVALIDATED: 0x20000000,
+
   openProcess(processIdentifier, callback) {
     if (arguments.length === 1) {
       return memoryjs.openProcess(processIdentifier);
@@ -83,6 +101,8 @@ module.exports = {
 
     memoryjs.findPattern(handle, moduleName, signature, signatureType, patternOffset, addressOffset, callback);
   },
+
+  setProtection: memoryjs.setProtection,
 
   closeProcess: memoryjs.closeProcess,
 };

--- a/lib/memory.h
+++ b/lib/memory.h
@@ -46,6 +46,11 @@ public:
   void writeMemory(HANDLE hProcess, DWORD64 dwAddress, char* value, SIZE_T size) {
     WriteProcessMemory(hProcess, (LPVOID)dwAddress, value, size, NULL);
   }
+
+  // Set the protection of the memory, returns previous protection.
+  void setProtection(HANDLE hProcess, DWORD64 dwAddress, SIZE_T size, DWORD dwProtection, PDWORD dwOldProtection) {
+	  VirtualProtectEx(hProcess, (LPVOID)dwAddress, size, dwProtection, dwOldProtection);
+  }
 };
 #endif
 #pragma once

--- a/lib/memoryjs.cc
+++ b/lib/memoryjs.cc
@@ -621,6 +621,31 @@ void findPattern(const FunctionCallbackInfo<Value>& args) {
   }
 }
 
+// Arguments:
+//   Process Handle
+//   Address
+//   Size
+//   Protection
+// Returns:
+//   Old Protection as a DWORD (unsigned int).
+void setProtection(const FunctionCallbackInfo<Value>& args) {
+	Isolate* isolate = args.GetIsolate();
+
+	if (args.Length() != 4) {
+		memoryjs::throwError("requires 4 arguments", isolate);
+		return;
+	}
+
+	if (!args[0]->IsNumber() && !args[1]->IsNumber() && !args[2]->IsNumber()) {
+		memoryjs::throwError("All arguments should be numbers.", isolate);
+		return;
+	}
+
+	DWORD result;
+	Memory.setProtection((HANDLE)args[0]->Uint32Value(), args[1]->Uint32Value(), args[2]->Uint32Value(), args[3]->Uint32Value(), &result);
+	args.GetReturnValue().Set(Number::New(isolate, result));
+}
+
 void init(Local<Object> exports) {
   NODE_SET_METHOD(exports, "openProcess", openProcess);
   NODE_SET_METHOD(exports, "closeProcess", closeProcess);
@@ -630,6 +655,7 @@ void init(Local<Object> exports) {
   NODE_SET_METHOD(exports, "readMemory", readMemory);
   NODE_SET_METHOD(exports, "writeMemory", writeMemory);
   NODE_SET_METHOD(exports, "findPattern", findPattern);
+  NODE_SET_METHOD(exports, "setProtection", setProtection);
 }
 
 NODE_MODULE(memoryjs, init)

--- a/test/protectionTest.js
+++ b/test/protectionTest.js
@@ -1,0 +1,13 @@
+const memoryjs = require('../index');
+const processName = 'TestTarget.exe';
+
+// TODO: Start the TestTarget process, and monitor it's return value.
+
+const processObject = memoryjs.openProcess(processName);
+console.log(processObject);
+
+
+memoryjs.setProtection(processObject.handle, 0x01341046, 4, memoryjs.PAGE_EXECUTE_READWRITE);
+memoryjs.writeMemory(processObject.handle, 0x01341046, 1337, memoryjs.INT);
+
+memoryjs.closeProcess(processObject.handle);

--- a/test/src/TestTarget.cpp
+++ b/test/src/TestTarget.cpp
@@ -1,0 +1,71 @@
+// TestTarget.cpp : Defines the entry point for the console application.
+//
+#include <tchar.h>
+#include "stdio.h"
+#include <Windows.h>
+
+int value = 0;
+
+__declspec(noinline) void routine() {
+	value = 100;
+}
+
+
+int main()
+{
+	printf("This program will return an exit code of 0 if you successfuly modify the memory in the given time frame.\n\
+\nWe want to modify the .code section of this exe.\n\
+Address of operation is likely around: 0x%08X.\n\
+Look for the MOV opcode + from its address to get the value address and modify it's memory you will need to change protection on the section of memory.\n", &routine);
+
+
+	// Assert that the program is compiled and running with PAGE_EXECUTE_READ on the routine method.
+	MEMORY_BASIC_INFORMATION mbi;
+	if (VirtualQuery(&routine, &mbi, sizeof(mbi)) == 0) {
+		printf("Unable to query memory protection for some reason.\n");
+		return 1;
+	}
+	if (! (mbi.Protect & PAGE_EXECUTE_READ) ) {
+		printf("Warning: Expecting memory to be EXECUTE_READ\n");
+		return 1;
+	}
+
+	printf("The address of the value is at 0x%08X but please modify the code in the routine that is setting it to 100 to set it to something else.\n", &value);
+	printf("On MSVC 2017 Release mode x86 I'm getting this address 0x%08X.\n", ((char*)&routine) + 6);
+
+
+	int counter = 0;
+	while (1) {
+		// Intentionally set the value to this before and after the call.
+		value = 0xDEADBEEF;
+
+		routine();
+
+		if (value != 100) {
+			routine();
+			if (value != 100) {
+				return 0;
+			}
+			else {
+				printf("Please modify the code not the value in memory.\n");
+			}
+		}
+
+		value = 0xDEADBEEF;
+
+		Sleep(1000);
+		counter++;
+
+		if (value != 0xDEADBEEF) {
+			printf("You must modify the code not the value.\n");
+		}
+
+		if (counter > 60) {
+			break;
+		}
+	}
+
+	printf("Attempt time expired closing application as failed.\n");
+    return 1;
+}
+


### PR DESCRIPTION
Added setProcess method to change the protection on virtual memory.

An example usage of this is to allow for over-writing of assembly code in process memory.
For example to make a quick patch to an already compiled C++ executable as it runs.

Resolves #21 