### PR TITLE
Fixed Bug with sync readMemory

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ module.exports = {
   },
 
   findPattern(handle, moduleName, signature, signatureType, patternOffset, addressOffset, callback) {
-    if (arguments.length === 5) {
+    if (arguments.length === 6) {
       return memoryjs.findPattern(handle, moduleName, signature, signatureType, patternOffset, addressOffset);
     }
 

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ module.exports = {
   },
 
   readMemory(handle, address, dataType, callback) {
-    if (arguments.length === 2) {
+    if (arguments.length === 3) {
       return memoryjs.readMemory(handle, address, dataType.toLowerCase());
     }
 


### PR DESCRIPTION
the aruments are now either 3 or 4 and not 2 or 3 like before. The example1.js throw this error:

````
 memoryjs.readMemory(handle, address, dataType.toLowerCase(), callback);
             ^

TypeError: fourth argument must be a function
    at Object.readMemory (X:\Dokumente\p410n3.JS\node_modules\memoryjs\index.js:
64:14)
    at Object.<anonymous> (X:\Dokumente\p410n3.JS\node_modules\memoryjs\example1
.js:86:61)
    at Module._compile (module.js:652:30)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
    at Function.Module.runMain (module.js:693:10)
    at startup (bootstrap_node.js:191:16)
    at bootstrap_node.js:612:3
````