### PR TITLE
Update dependency versions, fix build issue and type mismatch errors

### DIFF
--- a/lib/debugger.cc
+++ b/lib/debugger.cc
@@ -25,7 +25,7 @@ bool debugger::detatch(DWORD processId) {
 }
 
 bool debugger::setHardwareBreakpoint(DWORD processId, DWORD64 address, Register reg, int trigger, int size) {
-  char* errorMessage = "";
+  const char* errorMessage = "";
   std::vector<THREADENTRY32> threads = module::getThreads(0, &errorMessage);
 
   if (strcmp(errorMessage, "")) {

--- a/lib/dll.h
+++ b/lib/dll.h
@@ -9,7 +9,7 @@
 #include <string>
 
 namespace dll {
-  bool inject(HANDLE handle, std::string dllPath, char** errorMessage, LPDWORD moduleHandle) {
+  bool inject(HANDLE handle, std::string dllPath, const char** errorMessage, LPDWORD moduleHandle) {
     // allocate space in target process memory for DLL path
     LPVOID targetProcessPath = VirtualAllocEx(handle, NULL, dllPath.length() + 1, MEM_COMMIT, PAGE_EXECUTE_READWRITE);
 
@@ -53,7 +53,7 @@ namespace dll {
     return *moduleHandle > 0;
   }
 
-  bool unload(HANDLE handle, char** errorMessage, HMODULE moduleHandle) {
+  bool unload(HANDLE handle, const char** errorMessage, HMODULE moduleHandle) {
     HMODULE kernel32 = LoadLibrary("kernel32");
 
     if (kernel32 == 0) {

--- a/lib/functions.h
+++ b/lib/functions.h
@@ -33,7 +33,7 @@ namespace functions {
   char readChar(HANDLE hProcess, DWORD64 address);
 
   template <class returnDataType>
-  Call call(HANDLE pHandle, std::vector<Arg> args, Type returnType, DWORD64 address, char** errorMessage) {
+  Call call(HANDLE pHandle, std::vector<Arg> args, Type returnType, DWORD64 address, const char** errorMessage) {
     std::vector<unsigned char> argShellcode;
 
     std::reverse(args.begin(), args.end());

--- a/lib/memoryjs.cc
+++ b/lib/memoryjs.cc
@@ -48,7 +48,7 @@ Napi::Value openProcess(const Napi::CallbackInfo& args) {
   }
 
   // Define error message that may be set by the function that opens the process
-  char* errorMessage = "";
+  const char* errorMessage = "";
 
   process::Pair pair;
 
@@ -125,7 +125,7 @@ Napi::Value getProcesses(const Napi::CallbackInfo& args) {
   }
 
   // Define error message that may be set by the function that gets the processes
-  char* errorMessage = "";
+  const char* errorMessage = "";
 
   std::vector<PROCESSENTRY32> processEntries = Process.getProcesses(&errorMessage);
 
@@ -186,7 +186,7 @@ Napi::Value getModules(const Napi::CallbackInfo& args) {
   }
 
   // Define error message that may be set by the function that gets the modules
-  char* errorMessage = "";
+  const char* errorMessage = "";
 
   std::vector<MODULEENTRY32> moduleEntries = module::getModules(args[0].As<Napi::Number>().Int32Value(), &errorMessage);
 
@@ -251,7 +251,7 @@ Napi::Value findModule(const Napi::CallbackInfo& args) {
   std::string moduleName(args[0].As<Napi::String>().Utf8Value());
 
   // Define error message that may be set by the function that gets the modules
-  char* errorMessage = "";
+  const char* errorMessage = "";
 
   MODULEENTRY32 module = module::findModule(moduleName.c_str(), args[1].As<Napi::Number>().Int32Value(), &errorMessage);
 
@@ -312,7 +312,7 @@ Napi::Value readMemory(const Napi::CallbackInfo& args) {
   const char* dataType = dataTypeArg.c_str();
 
   // Define the error message that will be set if no data type is recognised
-  char* errorMessage = "";
+  const char* errorMessage = "";
   Napi::Value retVal = env.Null();
 
   HANDLE handle = (HANDLE)args[0].As<Napi::Number>().Int64Value();
@@ -743,7 +743,7 @@ Napi::Value findPattern(const Napi::CallbackInfo& args) {
 
   // matching address
   uintptr_t address = 0;
-  char* errorMessage = "";
+  const char* errorMessage = "";
 
   std::vector<MODULEENTRY32> modules = module::getModules(GetProcessId(handle), &errorMessage);
   Pattern.search(handle, modules, 0, pattern.c_str(), flags, patternOffset, &address);
@@ -793,7 +793,7 @@ Napi::Value findPatternByModule(const Napi::CallbackInfo& args) {
 
   // matching address
   uintptr_t address = 0;
-  char* errorMessage = "";
+  const char* errorMessage = "";
 
   MODULEENTRY32 module = module::findModule(moduleName.c_str(), GetProcessId(handle), &errorMessage);
 
@@ -854,7 +854,7 @@ Napi::Value findPatternByAddress(const Napi::CallbackInfo& args) {
 
   // matching address
   uintptr_t address = 0;
-  char* errorMessage = "";
+  const char* errorMessage = "";
 
   std::vector<MODULEENTRY32> modules = module::getModules(GetProcessId(handle), &errorMessage);
   Pattern.search(handle, modules, baseAddress, pattern.c_str(), flags, patternOffset, &address);
@@ -945,7 +945,7 @@ Napi::Value callFunction(const Napi::CallbackInfo& args) {
     address = args[3].As<Napi::Number>().Int64Value();
   }
 
-  char* errorMessage = "";
+  const char* errorMessage = "";
   Call data = functions::call<int>(handle, parsedArgs, returnType, address, &errorMessage);
 
   // Free all the memory we allocated
@@ -1030,7 +1030,7 @@ Napi::Value virtualProtectEx(const Napi::CallbackInfo& args) {
 
   bool success = VirtualProtectEx(handle, (LPVOID) address, size, protection, &result);
 
-  char* errorMessage = "";
+  const char* errorMessage = "";
 
   if (success == 0) {
     errorMessage = "an error occurred calling VirtualProtectEx";
@@ -1135,7 +1135,7 @@ Napi::Value virtualQueryEx(const Napi::CallbackInfo& args) {
   MEMORY_BASIC_INFORMATION information;
   SIZE_T result = VirtualQueryEx(handle, (LPVOID)address, &information, sizeof(information));
 
-  char* errorMessage = "";
+  const char* errorMessage = "";
 
   if (result == 0 || result != sizeof(information)) {
     errorMessage = "an error occurred calling VirtualQueryEx";
@@ -1202,7 +1202,7 @@ Napi::Value virtualAllocEx(const Napi::CallbackInfo& args) {
 
   LPVOID allocatedAddress = VirtualAllocEx(handle, address, size, allocationType, protection);
 
-  char* errorMessage = "";
+  const char* errorMessage = "";
 
   // If null, it means an error occurred
   if (allocatedAddress == NULL) {
@@ -1402,7 +1402,7 @@ Napi::Value injectDll(const Napi::CallbackInfo& args) {
   std::string dllPath(args[1].As<Napi::String>().Utf8Value());
   Napi::Function callback = args[2].As<Napi::Function>();
 
-  char* errorMessage = "";
+  const char* errorMessage = "";
   DWORD moduleHandle = -1;
   bool success = dll::inject(handle, dllPath, &errorMessage, &moduleHandle);
 
@@ -1463,7 +1463,7 @@ Napi::Value unloadDll(const Napi::CallbackInfo& args) {
   // find module handle from name of DLL
   if (args[1].IsString()) {
     std::string moduleName(args[1].As<Napi::String>().Utf8Value());
-    char* errorMessage = "";
+    const char* errorMessage = "";
 
     MODULEENTRY32 module = module::findModule(moduleName.c_str(), GetProcessId(handle), &errorMessage);
 
@@ -1480,7 +1480,7 @@ Napi::Value unloadDll(const Napi::CallbackInfo& args) {
     moduleHandle = (HMODULE) module.modBaseAddr;
   }
 
-  char* errorMessage = "";
+  const char* errorMessage = "";
   bool success = dll::unload(handle, &errorMessage, moduleHandle);
 
   if (strcmp(errorMessage, "") && args.Length() != 3) {

--- a/lib/module.cc
+++ b/lib/module.cc
@@ -7,12 +7,12 @@
 #include "memoryjs.h"
 
 DWORD64 module::getBaseAddress(const char* processName, DWORD processId) {
-  char* errorMessage = "";
+  const char* errorMessage = "";
   MODULEENTRY32 baseModule = module::findModule(processName, processId, &errorMessage);
   return (DWORD64)baseModule.modBaseAddr; 
 }
 
-MODULEENTRY32 module::findModule(const char* moduleName, DWORD processId, char** errorMessage) {
+MODULEENTRY32 module::findModule(const char* moduleName, DWORD processId, const char** errorMessage) {
   MODULEENTRY32 module;
   bool found = false;
 
@@ -36,7 +36,7 @@ MODULEENTRY32 module::findModule(const char* moduleName, DWORD processId, char**
   return module;
 } 
 
-std::vector<MODULEENTRY32> module::getModules(DWORD processId, char** errorMessage) {
+std::vector<MODULEENTRY32> module::getModules(DWORD processId, const char** errorMessage) {
   // Take a snapshot of all modules inside a given process.
   HANDLE hModuleSnapshot = CreateToolhelp32Snapshot(TH32CS_SNAPMODULE | TH32CS_SNAPMODULE32, processId);
   MODULEENTRY32 mEntry;
@@ -67,7 +67,7 @@ std::vector<MODULEENTRY32> module::getModules(DWORD processId, char** errorMessa
   return modules;
 }
 
-std::vector<THREADENTRY32> module::getThreads(DWORD processId, char** errorMessage) {
+std::vector<THREADENTRY32> module::getThreads(DWORD processId, const char** errorMessage) {
   HANDLE hThreadSnapshot = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, processId);
   THREADENTRY32 mEntry;
 

--- a/lib/module.h
+++ b/lib/module.h
@@ -9,9 +9,9 @@
 
 namespace module {
   DWORD64 getBaseAddress(const char* processName, DWORD processId);
-  MODULEENTRY32 findModule(const char* moduleName, DWORD processId, char** errorMessage);
-  std::vector<MODULEENTRY32> getModules(DWORD processId, char** errorMessage);
-  std::vector<THREADENTRY32> getThreads(DWORD processId, char** errorMessage);
+  MODULEENTRY32 findModule(const char* moduleName, DWORD processId, const char** errorMessage);
+  std::vector<MODULEENTRY32> getModules(DWORD processId, const char** errorMessage);
+  std::vector<THREADENTRY32> getThreads(DWORD processId, const char** errorMessage);
 
 };
 #endif

--- a/lib/process.cc
+++ b/lib/process.cc
@@ -12,7 +12,7 @@ using v8::Exception;
 using v8::Isolate;
 using v8::String;
 
-process::Pair process::openProcess(const char* processName, char** errorMessage){
+process::Pair process::openProcess(const char* processName, const char** errorMessage){
   PROCESSENTRY32 process;
   HANDLE handle = NULL;
 
@@ -38,7 +38,7 @@ process::Pair process::openProcess(const char* processName, char** errorMessage)
   };
 }
 
-process::Pair process::openProcess(DWORD processId, char** errorMessage) {
+process::Pair process::openProcess(DWORD processId, const char** errorMessage) {
   PROCESSENTRY32 process;
   HANDLE handle = NULL;
 
@@ -64,7 +64,7 @@ process::Pair process::openProcess(DWORD processId, char** errorMessage) {
   };
 }
 
-std::vector<PROCESSENTRY32> process::getProcesses(char** errorMessage) {
+std::vector<PROCESSENTRY32> process::getProcesses(const char** errorMessage) {
   // Take a snapshot of all processes.
   HANDLE hProcessSnapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, NULL);
   PROCESSENTRY32 pEntry;

--- a/lib/process.h
+++ b/lib/process.h
@@ -17,10 +17,10 @@ public:
   process();
   ~process();
 
-  Pair openProcess(const char* processName, char** errorMessage);
-  Pair openProcess(DWORD processId, char** errorMessage);
+  Pair openProcess(const char* processName, const char** errorMessage);
+  Pair openProcess(DWORD processId, const char** errorMessage);
   void closeProcess(HANDLE hProcess);
-  std::vector<PROCESSENTRY32> getProcesses(char** errorMessage);
+  std::vector<PROCESSENTRY32> getProcesses(const char** errorMessage);
 };
 
 #endif

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memoryjs",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Node add-on for memory reading and writing!",
   "main": "index.js",
   "scripts": {
@@ -33,8 +33,8 @@
   },
   "homepage": "https://github.com/Rob--/memoryjs#readme",
   "dependencies": {
-    "eslint": "^8.5.0",
-    "eslint-config-airbnb-base": "^12.1.0",
-    "node-addon-api": "^3.2.1"
+    "eslint": "^9.4.0",
+    "eslint-config-airbnb-base": "^15.0.0",
+    "node-addon-api": "^8.0.0"
   }
 }

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -15,7 +15,7 @@ function run(script) {
   const args = script.split(' ').slice(1);
 
   // inherit stdio to print colour (helpful for warnings/errors readability)
-  const child = spawn(program, args, { stdio: 'inherit' });
+  const child = spawn(program, args, { stdio: 'inherit', shell:true });
 
   child.on('close', code => console.log(`Script "${script}" exited with ${code}`));
 }


### PR DESCRIPTION
Build issue due to security patch (https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2/)

TODO - Resolve Warnings:
```
C:\memoryjs\lib\functions.h(65,26): warning C4311: 'type cast': pointer truncation from 'LPVOID' to 'int' [C:\memoryjs\build\memoryjs.vcxproj]
  (compiling source file '../lib/memoryjs.cc')
  C:\memoryjs\lib\functions.h(65,26):
  the template instantiation context (the oldest one first) is
        C:\memoryjs\lib\memoryjs.cc(949,26):
        see reference to function template instantiation 'Call functions::call<int>(HANDLE,std::vector<functions::Arg,std::allocator<functions::Arg>>,functions::Type,DWORD64,const char **)' being compiled

C:\memoryjs\lib\functions.h(65,26): warning C4302: 'type cast': truncation from 'LPVOID' to 'int' [C:\memoryjs\build\memoryjs.vcxproj]
  (compiling source file '../lib/memoryjs.cc')

C:\memoryjs\lib\functions.h(116,24): warning C4311: 'type cast': pointer truncation from 'LPVOID' to 'DWORD' [C:\memoryjs\build\memoryjs.vcxproj]
  (compiling source file '../lib/memoryjs.cc')

C:\memoryjs\lib\functions.h(116,24): warning C4302: 'type cast': truncation from 'LPVOID' to 'DWORD' [C:\memoryjs\build\memoryjs.vcxproj]
  (compiling source file '../lib/memoryjs.cc')
```